### PR TITLE
Implement basic screens and simple navigation

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,10 +1,22 @@
+import React, { useState } from 'react';
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import HomeScreen from './screens/HomeScreen';
+import LoginScreen from './screens/LoginScreen';
+import ScheduleScreen from './screens/ScheduleScreen';
+import NavigationBar from './components/NavigationBar';
 
 export default function App() {
+  const [screen, setScreen] = useState('Home');
+
+  let Current = HomeScreen;
+  if (screen === 'Login') Current = LoginScreen;
+  else if (screen === 'Schedule') Current = ScheduleScreen;
+
   return (
-    <View style={styles.container}>
-      <Text>Open up App.js to start working on your app!</Text>
+    <View style={styles.container} testID="app-root">
+      <Current />
+      <NavigationBar navigate={setScreen} />
       <StatusBar style="auto" />
     </View>
   );
@@ -14,7 +26,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#fff',
-    alignItems: 'center',
     justifyContent: 'center',
   },
 });

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This app is **not** specific to any one state or program and is intended to be *
 
 ## Project Status
 
-**This project is in the initial setup phase.**  
+**This project is in the initial setup phase.** Basic navigation screens are included for initial testing.  
 Core requirements and architecture are being defined. No stable code or release yet.
 
 ---

--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -1,0 +1,9 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createElement } from 'react';
+import App from '../App.js';
+
+test('App renders root view', () => {
+  const element = createElement(App);
+  assert.strictEqual(element.type, App);
+});

--- a/__tests__/HomeScreen.test.js
+++ b/__tests__/HomeScreen.test.js
@@ -1,0 +1,9 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createElement } from 'react';
+import HomeScreen from '../screens/HomeScreen.js';
+
+test('HomeScreen renders', () => {
+  const element = createElement(HomeScreen);
+  assert.strictEqual(element.type, HomeScreen);
+});

--- a/__tests__/LoginScreen.test.js
+++ b/__tests__/LoginScreen.test.js
@@ -1,0 +1,9 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createElement } from 'react';
+import LoginScreen from '../screens/LoginScreen.js';
+
+test('LoginScreen renders', () => {
+  const element = createElement(LoginScreen);
+  assert.strictEqual(element.type, LoginScreen);
+});

--- a/__tests__/ScheduleScreen.test.js
+++ b/__tests__/ScheduleScreen.test.js
@@ -1,0 +1,9 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createElement } from 'react';
+import ScheduleScreen from '../screens/ScheduleScreen.js';
+
+test('ScheduleScreen renders', () => {
+  const element = createElement(ScheduleScreen);
+  assert.strictEqual(element.type, ScheduleScreen);
+});

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "boys-state-app",
-    "slug": "boys-state-app",
+    "name": "Boys State Demo",
+    "slug": "boys-state-demo",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/components/NavigationBar.js
+++ b/components/NavigationBar.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { View, Button, StyleSheet } from 'react-native';
+
+export default function NavigationBar({ navigate }) {
+  return (
+    <View style={styles.nav} testID="nav-bar">
+      <Button title="Home" onPress={() => navigate('Home')} />
+      <Button title="Login" onPress={() => navigate('Login')} />
+      <Button title="Schedule" onPress={() => navigate('Schedule')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  nav: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    paddingVertical: 10,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "node --test"
   },
   "dependencies": {
     "expo": "~53.0.12",

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function HomeScreen() {
+  return (
+    <View style={styles.container} testID="home-screen">
+      <Text accessibilityRole="header">Home Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function LoginScreen() {
+  return (
+    <View style={styles.container} testID="login-screen">
+      <Text accessibilityRole="header">Login Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/screens/ScheduleScreen.js
+++ b/screens/ScheduleScreen.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function ScheduleScreen() {
+  return (
+    <View style={styles.container} testID="schedule-screen">
+      <Text accessibilityRole="header">Schedule Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});


### PR DESCRIPTION
## Summary
- add Home, Login, and Schedule screens
- add simple navigation bar component
- switch between screens in `App.js`
- update branding in `app.json`
- mention new navigation in `README`
- add minimal tests using Node's built-in test runner

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token '<')*

------
https://chatgpt.com/codex/tasks/task_b_68572e015f88832da69e02496ee550d1