### PR TITLE
Convert tests to jest

### DIFF
--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -1,9 +1,7 @@
-import test from 'node:test';
-import assert from 'node:assert';
 import { createElement } from 'react';
 import App from '../App.js';
 
 test('App renders root view', () => {
   const element = createElement(App);
-  assert.strictEqual(element.type, App);
+  expect(element.type).toBe(App);
 });

--- a/__tests__/HomeScreen.test.js
+++ b/__tests__/HomeScreen.test.js
@@ -1,9 +1,7 @@
-import test from 'node:test';
-import assert from 'node:assert';
 import { createElement } from 'react';
 import HomeScreen from '../screens/HomeScreen.js';
 
 test('HomeScreen renders', () => {
   const element = createElement(HomeScreen);
-  assert.strictEqual(element.type, HomeScreen);
+  expect(element.type).toBe(HomeScreen);
 });

--- a/__tests__/LoginScreen.test.js
+++ b/__tests__/LoginScreen.test.js
@@ -1,9 +1,7 @@
-import test from 'node:test';
-import assert from 'node:assert';
 import { createElement } from 'react';
 import LoginScreen from '../screens/LoginScreen.js';
 
 test('LoginScreen renders', () => {
   const element = createElement(LoginScreen);
-  assert.strictEqual(element.type, LoginScreen);
+  expect(element.type).toBe(LoginScreen);
 });

--- a/__tests__/ScheduleScreen.test.js
+++ b/__tests__/ScheduleScreen.test.js
@@ -1,9 +1,7 @@
-import test from 'node:test';
-import assert from 'node:assert';
 import { createElement } from 'react';
 import ScheduleScreen from '../screens/ScheduleScreen.js';
 
 test('ScheduleScreen renders', () => {
   const element = createElement(ScheduleScreen);
-  assert.strictEqual(element.type, ScheduleScreen);
+  expect(element.type).toBe(ScheduleScreen);
 });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "test": "node --test"
+    "test": "jest"
   },
   "dependencies": {
     "expo": "~53.0.12",
@@ -20,7 +20,8 @@
     "@expo/metro-runtime": "~5.0.4"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0"
+    "@babel/core": "^7.20.0",
+    "jest": "^29.7.0"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- update test scripts to run Jest
- convert existing Node.js tests to Jest

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68576767be7c832d85aac14fdde55626