### PR TITLE
Fix Jest tests

### DIFF
--- a/__mocks__/expo-status-bar.js
+++ b/__mocks__/expo-status-bar.js
@@ -1,0 +1,3 @@
+module.exports = {
+  StatusBar: () => null,
+};

--- a/__mocks__/react-native.js
+++ b/__mocks__/react-native.js
@@ -1,0 +1,9 @@
+const React = require('react');
+
+module.exports = {
+  View: (props) => React.createElement('View', props, props.children),
+  Text: (props) => React.createElement('Text', props, props.children),
+  StyleSheet: {
+    create: styles => styles,
+  },
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,5 @@
 module.exports = {
   preset: 'react-native',
   setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
-  transformIgnorePatterns: [
-    "node_modules/(?!((jest-)?react-native|@react-native(-community)?|@react-navigation|@react-native|react-native|expo(-.*)?|@expo(-.*)?|@unimodules/.*|sentry-expo|native-base))"
-  ],
+  setupFiles: ['<rootDir>/jest.setup.js'],
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,2 @@
+jest.mock('react-native');
+jest.mock('expo-status-bar');


### PR DESCRIPTION
## Summary
- configure Jest to use a setup file
- add mocks for `react-native` and `expo-status-bar`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68576ae8cafc832d9b8ebdb2675451c4