### PR TITLE
Improve test coverage to 100%

### DIFF
--- a/__mocks__/react-native.js
+++ b/__mocks__/react-native.js
@@ -3,7 +3,10 @@ const React = require('react');
 module.exports = {
   View: (props) => React.createElement('View', props, props.children),
   Text: (props) => React.createElement('Text', props, props.children),
+  Button: ({ onPress, title, testID }) =>
+    React.createElement('Text', { onPress, testID }, title),
   StyleSheet: {
     create: styles => styles,
+    flatten: style => style,
   },
 };

--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -1,7 +1,19 @@
-import { createElement } from 'react';
-import App from '../App.js';
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import App from '../App';
 
-test('App renders root view', () => {
-  const element = createElement(App);
-  expect(element.type).toBe(App);
+test('App navigates between screens', () => {
+  const { getByText } = render(<App />);
+
+  // initial screen
+  expect(getByText('Home Screen')).toBeTruthy();
+
+  fireEvent.press(getByText('Login'));
+  expect(getByText('Login Screen')).toBeTruthy();
+
+  fireEvent.press(getByText('Schedule'));
+  expect(getByText('Schedule Screen')).toBeTruthy();
+
+  fireEvent.press(getByText('Home'));
+  expect(getByText('Home Screen')).toBeTruthy();
 });

--- a/__tests__/HomeScreen.test.js
+++ b/__tests__/HomeScreen.test.js
@@ -1,7 +1,8 @@
-import { createElement } from 'react';
-import HomeScreen from '../screens/HomeScreen.js';
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import HomeScreen from '../screens/HomeScreen';
 
-test('HomeScreen renders', () => {
-  const element = createElement(HomeScreen);
-  expect(element.type).toBe(HomeScreen);
+test('displays Home Screen header', () => {
+  const { getByRole } = render(<HomeScreen />);
+  expect(getByRole('header').props.children).toBe('Home Screen');
 });

--- a/__tests__/LoginScreen.test.js
+++ b/__tests__/LoginScreen.test.js
@@ -1,7 +1,8 @@
-import { createElement } from 'react';
-import LoginScreen from '../screens/LoginScreen.js';
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import LoginScreen from '../screens/LoginScreen';
 
-test('LoginScreen renders', () => {
-  const element = createElement(LoginScreen);
-  expect(element.type).toBe(LoginScreen);
+test('displays Login Screen header', () => {
+  const { getByRole } = render(<LoginScreen />);
+  expect(getByRole('header').props.children).toBe('Login Screen');
 });

--- a/__tests__/NavigationBar.test.js
+++ b/__tests__/NavigationBar.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import NavigationBar from '../components/NavigationBar';
+
+test('calls navigate with correct screen names', () => {
+  const navigate = jest.fn();
+  const { getByText } = render(<NavigationBar navigate={navigate} />);
+
+  fireEvent.press(getByText('Home'));
+  fireEvent.press(getByText('Login'));
+  fireEvent.press(getByText('Schedule'));
+
+  expect(navigate).toHaveBeenCalledWith('Home');
+  expect(navigate).toHaveBeenCalledWith('Login');
+  expect(navigate).toHaveBeenCalledWith('Schedule');
+});

--- a/__tests__/ScheduleScreen.test.js
+++ b/__tests__/ScheduleScreen.test.js
@@ -1,7 +1,8 @@
-import { createElement } from 'react';
-import ScheduleScreen from '../screens/ScheduleScreen.js';
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import ScheduleScreen from '../screens/ScheduleScreen';
 
-test('ScheduleScreen renders', () => {
-  const element = createElement(ScheduleScreen);
-  expect(element.type).toBe(ScheduleScreen);
+test('displays Schedule Screen header', () => {
+  const { getByRole } = render(<ScheduleScreen />);
+  expect(getByRole('header').props.children).toBe('Schedule Screen');
 });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,0 +1,8 @@
+import App from '../App';
+jest.mock('expo', () => ({ registerRootComponent: jest.fn() }));
+import { registerRootComponent } from 'expo';
+
+test('registers root component', () => {
+  require('../index');
+  expect(registerRootComponent).toHaveBeenCalledWith(App);
+});


### PR DESCRIPTION
## Summary
- add Button mock and StyleSheet.flatten to react-native mock
- rewrite component tests using @testing-library/react-native
- add NavigationBar and index tests
- verify navigation logic in App component

## Testing
- `npm test --silent`
- `npx jest --coverage`

------
https://chatgpt.com/codex/tasks/task_b_68576e317158832d8068e620bb979114