### PR TITLE
Fix React version mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,11 @@
         "@expo/metro-runtime": "~5.0.4",
         "expo": "~53.0.12",
         "expo-status-bar": "~2.2.3",
-        "react": "^19.1.0",
+        "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-native": "0.79.4",
         "react-native-web": "^0.20.0",
-        "react-test-renderer": "^19.1.0"
+        "react-test-renderer": "19.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.27.4",
@@ -12762,8 +12762,8 @@
       }
     },
     "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
       "engines": {
@@ -13036,21 +13036,21 @@
       }
     },
     "node_modules/react-test-renderer": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.0.0.tgz",
       "integrity": "sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==",
       "license": "MIT",
       "dependencies": {
-        "react-is": "^19.1.0",
+        "react-is": "^19.0.0",
         "scheduler": "^0.26.0"
       },
       "peerDependencies": {
-        "react": "^19.1.0"
+        "react": "^19.0.0"
       }
     },
     "node_modules/react-test-renderer/node_modules/react-is": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
       "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
     "@expo/metro-runtime": "~5.0.4",
     "expo": "~53.0.12",
     "expo-status-bar": "~2.2.3",
-    "react": "^19.1.0",
+    "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.4",
     "react-native-web": "^0.20.0",
-    "react-test-renderer": "^19.1.0"
+    "react-test-renderer": "19.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.27.4",


### PR DESCRIPTION
## Summary
- keep React packages on 19.0.0 to match React Native

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68576f9e55e8832d84eb59466a91a2ee