### PR TITLE
Add API status checker

### DIFF
--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -2,6 +2,11 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import App from '../App';
 
+beforeEach(() => {
+  fetch.mockReset();
+  fetch.mockResolvedValue({ json: () => Promise.resolve({}) });
+});
+
 test('App navigates between screens', () => {
   const { getByText } = render(<App />);
 

--- a/__tests__/HomeScreen.test.js
+++ b/__tests__/HomeScreen.test.js
@@ -1,8 +1,38 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, waitFor } from '@testing-library/react-native';
 import HomeScreen from '../screens/HomeScreen';
 
+beforeEach(() => {
+  fetch.mockReset();
+  fetch.mockResolvedValue({ json: () => Promise.resolve({}) });
+});
+
+afterEach(() => {
+  delete global.__DEV__;
+});
+
 test('displays Home Screen header', () => {
+  global.__DEV__ = true;
   const { getByRole } = render(<HomeScreen />);
   expect(getByRole('header').props.children).toBe('Home Screen');
+});
+
+test('fetches status from localhost in dev', async () => {
+  global.__DEV__ = true;
+  fetch.mockResolvedValue({ json: () => Promise.resolve({ api: 'ok', db: 'ok' }) });
+  const { getByText } = render(<HomeScreen />);
+
+  await waitFor(() => expect(fetch).toHaveBeenCalledWith('http://localhost:3000/status'));
+  await waitFor(() => getByText('API Status: ok'));
+  await waitFor(() => getByText('DB Status: ok'));
+});
+
+test('fetches status from production api in prod', async () => {
+  global.__DEV__ = false;
+  fetch.mockResolvedValue({ json: () => Promise.resolve({ api: 'ok', db: 'ok' }) });
+  const { getByText } = render(<HomeScreen />);
+
+  await waitFor(() => expect(fetch).toHaveBeenCalledWith('https://boysstateappservices.up.railway.app/status'));
+  await waitFor(() => getByText('API Status: ok'));
+  await waitFor(() => getByText('DB Status: ok'));
 });

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,2 +1,4 @@
 jest.mock('react-native');
 jest.mock('expo-status-bar');
+
+global.fetch = jest.fn();

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,10 +1,40 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 
+function getBaseUrl() {
+  return __DEV__
+    ? 'http://localhost:3000'
+    : 'https://boysstateappservices.up.railway.app';
+}
+
 export default function HomeScreen() {
+  const [apiStatus, setApiStatus] = useState(null);
+  const [dbStatus, setDbStatus] = useState(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    fetch(`${getBaseUrl()}/status`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (!isMounted) return;
+        setApiStatus(data.api || 'unknown');
+        setDbStatus(data.db || 'unknown');
+      })
+      .catch(() => {
+        if (!isMounted) return;
+        setApiStatus('error');
+        setDbStatus('error');
+      });
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
   return (
     <View style={styles.container} testID="home-screen">
       <Text accessibilityRole="header">Home Screen</Text>
+      <Text>API Status: {apiStatus || 'loading'}</Text>
+      <Text>DB Status: {dbStatus || 'loading'}</Text>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- check API connectivity on Home screen
- mock fetch for testing
- test API URL selection for dev/prod

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68581dc09f8c832d8d3874a6840776cd