### PR TITLE
Improve navigation bar placement and styling

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, SafeAreaView } from 'react-native';
 import HomeScreen from './screens/HomeScreen';
 import LoginScreen from './screens/LoginScreen';
 import ScheduleScreen from './screens/ScheduleScreen';
@@ -14,11 +14,11 @@ export default function App() {
   else if (screen === 'Schedule') Current = ScheduleScreen;
 
   return (
-    <View style={styles.container} testID="app-root">
-      <Current />
+    <SafeAreaView style={styles.container} testID="app-root">
       <NavigationBar navigate={setScreen} />
+      <Current />
       <StatusBar style="auto" />
-    </View>
+    </SafeAreaView>
   );
 }
 
@@ -26,6 +26,5 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#fff',
-    justifyContent: 'center',
   },
 });

--- a/__mocks__/react-native.js
+++ b/__mocks__/react-native.js
@@ -5,6 +5,9 @@ module.exports = {
   Text: (props) => React.createElement('Text', props, props.children),
   Button: ({ onPress, title, testID }) =>
     React.createElement('Text', { onPress, testID }, title),
+  TouchableOpacity: (props) =>
+    React.createElement('Text', { onPress: props.onPress, testID: props.testID }, props.children),
+  SafeAreaView: (props) => React.createElement('View', props, props.children),
   StyleSheet: {
     create: styles => styles,
     flatten: style => style,

--- a/components/NavigationBar.js
+++ b/components/NavigationBar.js
@@ -1,12 +1,24 @@
 import React from 'react';
-import { View, Button, StyleSheet } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+
+function NavButton({ title, onPress }) {
+  return (
+    <TouchableOpacity
+      accessibilityRole="button"
+      style={styles.button}
+      onPress={onPress}
+    >
+      <Text style={styles.buttonText}>{title}</Text>
+    </TouchableOpacity>
+  );
+}
 
 export default function NavigationBar({ navigate }) {
   return (
     <View style={styles.nav} testID="nav-bar">
-      <Button title="Home" onPress={() => navigate('Home')} />
-      <Button title="Login" onPress={() => navigate('Login')} />
-      <Button title="Schedule" onPress={() => navigate('Schedule')} />
+      <NavButton title="Home" onPress={() => navigate('Home')} />
+      <NavButton title="Login" onPress={() => navigate('Login')} />
+      <NavButton title="Schedule" onPress={() => navigate('Schedule')} />
     </View>
   );
 }
@@ -16,5 +28,16 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-around',
     paddingVertical: 10,
+    backgroundColor: '#eee',
+  },
+  button: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    backgroundColor: '#007AFF',
+    borderRadius: 4,
+  },
+  buttonText: {
+    color: '#fff',
+    fontWeight: 'bold',
   },
 });

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -43,6 +43,8 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: 'flex-start',
+    paddingTop: 20,
+    backgroundColor: '#f2f2f2',
   },
 });

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -13,6 +13,8 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: 'flex-start',
+    paddingTop: 20,
+    backgroundColor: '#f2f2f2',
   },
 });

--- a/screens/ScheduleScreen.js
+++ b/screens/ScheduleScreen.js
@@ -13,6 +13,8 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: 'flex-start',
+    paddingTop: 20,
+    backgroundColor: '#f2f2f2',
   },
 });


### PR DESCRIPTION
## Summary
- move NavigationBar to the top of the screen via SafeAreaView
- replace default buttons with styled TouchableOpacity buttons
- update mocked react-native components for new primitives
- style screens with top padding and light background

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68589f29aa2c832d8aa4b4451c1ea4c0