### PR TITLE
Fix nav bar behind phone icons

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, SafeAreaView } from 'react-native';
+import { StatusBar as ExpoStatusBar } from 'expo-status-bar';
+import { StyleSheet, SafeAreaView, Platform, StatusBar } from 'react-native';
 import HomeScreen from './screens/HomeScreen';
 import LoginScreen from './screens/LoginScreen';
 import ScheduleScreen from './screens/ScheduleScreen';
@@ -17,7 +17,7 @@ export default function App() {
     <SafeAreaView style={styles.container} testID="app-root">
       <NavigationBar navigate={setScreen} />
       <Current />
-      <StatusBar style="auto" />
+      <ExpoStatusBar style="auto" />
     </SafeAreaView>
   );
 }
@@ -26,5 +26,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#fff',
+    paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0,
   },
 });

--- a/__mocks__/react-native.js
+++ b/__mocks__/react-native.js
@@ -12,4 +12,11 @@ module.exports = {
     create: styles => styles,
     flatten: style => style,
   },
+  Platform: {
+    OS: 'ios',
+    select: objs => objs['ios'],
+  },
+  StatusBar: {
+    currentHeight: 0,
+  },
 };


### PR DESCRIPTION
## Summary
- account for safe area on Android so the nav bar sits below the status bar
- update mock `react-native` module for new Platform and StatusBar usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6858a2e890a0832dac805425769fe650