### PR TITLE
Add functional login screen

### DIFF
--- a/__mocks__/react-native.js
+++ b/__mocks__/react-native.js
@@ -7,6 +7,8 @@ module.exports = {
     React.createElement('Text', { onPress, testID }, title),
   TouchableOpacity: (props) =>
     React.createElement('Text', { onPress: props.onPress, testID: props.testID }, props.children),
+  TextInput: (props) =>
+    React.createElement('TextInput', { onChangeText: props.onChangeText, value: props.value, placeholder: props.placeholder, secureTextEntry: props.secureTextEntry }, props.children),
   Image: (props) => React.createElement('Image', props, props.children),
   SafeAreaView: (props) => React.createElement('View', props, props.children),
   StyleSheet: {

--- a/__tests__/LoginScreen.test.js
+++ b/__tests__/LoginScreen.test.js
@@ -1,8 +1,27 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import LoginScreen from '../screens/LoginScreen';
 
 test('displays Login Screen header', () => {
   const { getByRole } = render(<LoginScreen />);
   expect(getByRole('header').props.children).toBe('Login Screen');
+});
+
+test('submits credentials to the API', async () => {
+  global.__DEV__ = true;
+  fetch.mockResolvedValueOnce({ json: () => Promise.resolve({ token: 't' }) });
+
+  const { getByPlaceholderText, getByText, getByTestId } = render(<LoginScreen />);
+  fireEvent.changeText(getByPlaceholderText('Email'), 'user@example.com');
+  fireEvent.changeText(getByPlaceholderText('Password'), 'pass');
+  fireEvent.press(getByText('Login'));
+
+  await waitFor(() => getByTestId('login-message'));
+
+  expect(fetch.mock.calls[0][0]).toBe('http://192.168.1.171:3000/login');
+  expect(JSON.parse(fetch.mock.calls[0][1].body)).toEqual({
+    email: 'user@example.com',
+    password: 'pass',
+  });
+  delete global.__DEV__;
 });

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -1,10 +1,69 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+} from 'react-native';
+
+const API_BASE = __DEV__
+  ? 'http://192.168.1.171:3000'
+  : 'https://boysstateappservices.up.railway.app';
 
 export default function LoginScreen() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleLogin = async () => {
+    setMessage('');
+    try {
+      const res = await fetch(`${API_BASE}/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      const data = await res.json();
+      if (data.token) {
+        setMessage('Logged in successfully!');
+      } else {
+        setMessage('Login failed');
+      }
+    } catch {
+      setMessage('Login failed');
+    }
+  };
+
   return (
     <View style={styles.container} testID="login-screen">
       <Text accessibilityRole="header">Login Screen</Text>
+      <TextInput
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        autoCapitalize="none"
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+        style={styles.input}
+      />
+      <TouchableOpacity
+        onPress={handleLogin}
+        style={styles.button}
+        accessibilityRole="button"
+      >
+        <Text style={styles.buttonText}>Login</Text>
+      </TouchableOpacity>
+      {!!message && (
+        <Text testID="login-message" style={styles.message}>
+          {message}
+        </Text>
+      )}
     </View>
   );
 }
@@ -16,5 +75,27 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-start',
     paddingTop: 20,
     backgroundColor: '#f2f2f2',
+  },
+  input: {
+    width: '90%',
+    padding: 10,
+    marginTop: 12,
+    backgroundColor: '#fff',
+    borderRadius: 4,
+  },
+  button: {
+    marginTop: 20,
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    backgroundColor: '#204080',
+    borderRadius: 4,
+  },
+  buttonText: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+  message: {
+    marginTop: 12,
+    fontSize: 16,
   },
 });


### PR DESCRIPTION
## Summary
- create functional LoginScreen with text inputs and API call
- update react-native mock to support TextInput
- add test ensuring the login screen hits the API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68710861c560832d94217f80149a9147