### PR TITLE
Enable login navigation and program theming

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,13 +1,54 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { SafeAreaView, StyleSheet, Platform, StatusBar } from 'react-native';
-import HomeScreen from './screens/HomeScreen'; // or wherever your HomeScreen lives
+import HomeScreen from './screens/HomeScreen';
+import LoginScreen from './screens/LoginScreen';
+import ScheduleScreen from './screens/ScheduleScreen';
 import { StatusBar as ExpoStatusBar } from 'expo-status-bar';
 
 export default function App() {
   const paddingTop = Platform.OS === 'android' ? StatusBar.currentHeight : 0;
+
+  const [currentScreen, setCurrentScreen] = useState('Home');
+  const [loggedIn, setLoggedIn] = useState(false);
+  const [program, setProgram] = useState(null);
+  const [branding, setBranding] = useState(null);
+
+  const handleLoginSuccess = ({ program: p, branding: b }) => {
+    setLoggedIn(true);
+    setProgram(p);
+    setBranding(b);
+    setCurrentScreen('Home');
+  };
+
+  const handleLogout = () => {
+    setLoggedIn(false);
+    setProgram(null);
+    setBranding(null);
+  };
+
+  let ScreenComponent;
+  if (currentScreen === 'Login') {
+    ScreenComponent = (
+      <LoginScreen onLoginSuccess={handleLoginSuccess} />
+    );
+  } else if (currentScreen === 'Schedule') {
+    ScreenComponent = <ScheduleScreen />;
+  } else {
+    ScreenComponent = (
+      <HomeScreen
+        loggedIn={loggedIn}
+        program={program}
+        branding={branding}
+        onPressLogin={() => setCurrentScreen('Login')}
+        onLogout={handleLogout}
+        onSchedule={() => setCurrentScreen('Schedule')}
+      />
+    );
+  }
+
   return (
     <SafeAreaView style={[styles.container, { paddingTop }]}>\
-      <HomeScreen />
+      {ScreenComponent}
       <ExpoStatusBar style="light" />
     </SafeAreaView>
   );

--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, fireEvent } from '@testing-library/react-native';
 
 test('renders home screen component', () => {
   const App = require('../App').default;
@@ -14,4 +14,11 @@ test('renders correctly on android', () => {
   const { getByTestId } = render(<App />);
   expect(getByTestId('program-name')).toBeTruthy();
   rn.Platform.OS = 'ios';
+});
+
+test('navigates to login screen when login pressed', () => {
+  const App = require('../App').default;
+  const { getByText, getByTestId } = render(<App />);
+  fireEvent.press(getByText('Login'));
+  expect(getByTestId('login-screen')).toBeTruthy();
 });

--- a/__tests__/HomeScreen.test.js
+++ b/__tests__/HomeScreen.test.js
@@ -1,54 +1,28 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { render, fireEvent } from '@testing-library/react-native';
 import HomeScreen from '../screens/HomeScreen';
 
-beforeEach(() => {
-  fetch.mockReset();
-});
+const program = { programId: 'abc', programName: 'Test Program' };
 
-afterEach(() => {
-  delete global.__DEV__;
-});
-
-test('login fetches program and branding in dev', async () => {
-  global.__DEV__ = true;
-  fetch
-    .mockResolvedValueOnce({ json: () => Promise.resolve({ token: 't' }) })
-    .mockResolvedValueOnce({
-      json: () => Promise.resolve({ programs: [{ programId: 'abc', programName: 'Test Program' }] }),
-    })
-    .mockResolvedValueOnce({ json: () => Promise.resolve({ colors: { primary: '#111', secondary: '#222' } }) });
-
-  const { getByText, getByTestId } = render(<HomeScreen />);
+test('calls onPressLogin when login button pressed', () => {
+  const onPressLogin = jest.fn();
+  const { getByText } = render(<HomeScreen onPressLogin={onPressLogin} />);
   fireEvent.press(getByText('Login'));
-
-  await waitFor(() => getByTestId('assigned-program'));
-
-  expect(fetch.mock.calls[0][0]).toBe('http://192.168.1.171:3000/login');
-  expect(fetch.mock.calls[1][0]).toBe('http://192.168.1.171:3000/user-programs/demo@example.com');
-  expect(fetch.mock.calls[2][0]).toBe('http://192.168.1.171:3000/api/branding-contact/abc');
-  expect(getByTestId('program-name').props.children).toContain('Test Program');
+  expect(onPressLogin).toHaveBeenCalled();
 });
 
 test('shows welcome message when logged out', () => {
-  global.__DEV__ = true;
   const { getByText } = render(<HomeScreen />);
-  expect(getByText("Log in to get started! You'll see your schedule and updates once you're signed in.")).toBeTruthy();
+  expect(
+    getByText("Log in to get started! You'll see your schedule and updates once you're signed in.")
+  ).toBeTruthy();
 });
 
-test('logout clears program info', async () => {
-  global.__DEV__ = true;
-  fetch
-    .mockResolvedValueOnce({ json: () => Promise.resolve({ token: 't' }) })
-    .mockResolvedValueOnce({
-      json: () => Promise.resolve({ programs: [{ programId: 'abc', programName: 'Test Program' }] }),
-    })
-    .mockResolvedValueOnce({ json: () => Promise.resolve({ colors: {} }) });
-
-  const { getByText, queryByTestId } = render(<HomeScreen />);
-  fireEvent.press(getByText('Login'));
-  await waitFor(() => getByText('Logout'));
+test('logout button triggers callback', () => {
+  const onLogout = jest.fn();
+  const { getByText } = render(
+    <HomeScreen loggedIn program={program} onLogout={onLogout} />
+  );
   fireEvent.press(getByText('Logout'));
-
-  expect(queryByTestId('assigned-program')).toBeNull();
+  expect(onLogout).toHaveBeenCalled();
 });

--- a/__tests__/LoginScreen.test.js
+++ b/__tests__/LoginScreen.test.js
@@ -7,11 +7,22 @@ test('displays Login Screen header', () => {
   expect(getByRole('header').props.children).toBe('Login Screen');
 });
 
-test('submits credentials to the API', async () => {
+test('submits credentials and fetches branding', async () => {
   global.__DEV__ = true;
-  fetch.mockResolvedValueOnce({ json: () => Promise.resolve({ token: 't' }) });
+  fetch
+    .mockResolvedValueOnce({ json: () => Promise.resolve({ token: 't' }) })
+    .mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({ programs: [{ programId: 'abc', programName: 'Test' }] }),
+    })
+    .mockResolvedValueOnce({
+      json: () => Promise.resolve({ colors: { primary: '#111', secondary: '#222' } }),
+    });
 
-  const { getByPlaceholderText, getByText, getByTestId } = render(<LoginScreen />);
+  const onLoginSuccess = jest.fn();
+  const { getByPlaceholderText, getByText, getByTestId } = render(
+    <LoginScreen onLoginSuccess={onLoginSuccess} />
+  );
   fireEvent.changeText(getByPlaceholderText('Email'), 'user@example.com');
   fireEvent.changeText(getByPlaceholderText('Password'), 'pass');
   fireEvent.press(getByText('Login'));
@@ -19,9 +30,16 @@ test('submits credentials to the API', async () => {
   await waitFor(() => getByTestId('login-message'));
 
   expect(fetch.mock.calls[0][0]).toBe('http://192.168.1.171:3000/login');
-  expect(JSON.parse(fetch.mock.calls[0][1].body)).toEqual({
-    email: 'user@example.com',
-    password: 'pass',
+  expect(fetch.mock.calls[1][0]).toBe(
+    'http://192.168.1.171:3000/user-programs/user@example.com'
+  );
+  expect(fetch.mock.calls[2][0]).toBe(
+    'http://192.168.1.171:3000/api/branding-contact/abc'
+  );
+  expect(onLoginSuccess).toHaveBeenCalledWith({
+    token: 't',
+    program: { programId: 'abc', programName: 'Test' },
+    branding: { colors: { primary: '#111', secondary: '#222' } },
   });
   delete global.__DEV__;
 });

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { View, Text, Image, StyleSheet, TouchableOpacity, Dimensions, Platform, StatusBar } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 
@@ -13,14 +13,14 @@ const COLORS = {
   transparent: 'rgba(255,255,255,0.08)',
 };
 
-const API_BASE = __DEV__
-  ? 'http://192.168.1.171:3000'
-  : 'https://boysstateappservices.up.railway.app';
-
-export default function HomeScreen() {
-  const [loggedIn, setLoggedIn] = useState(false);
-  const [program, setProgram] = useState(null);
-  const [branding, setBranding] = useState(null);
+export default function HomeScreen({
+  loggedIn = false,
+  program = null,
+  branding = null,
+  onPressLogin,
+  onLogout,
+  onSchedule,
+}) {
 
   useEffect(() => {
     if (branding && branding.colors) {
@@ -29,42 +29,18 @@ export default function HomeScreen() {
     }
   }, [branding]);
 
-  // Handlers
-  const handleLogin = async () => {
-    const email = 'demo@example.com';
-    const password = 'password';
-
-    const res = await fetch(`${API_BASE}/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password }),
-    });
-    const { token } = await res.json();
-
-    const programsRes = await fetch(`${API_BASE}/user-programs/${email}`, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    const programsData = await programsRes.json();
-    const firstProgram = programsData.programs?.[0];
-    setProgram(firstProgram);
-
-    if (firstProgram) {
-      const brandRes = await fetch(
-        `${API_BASE}/api/branding-contact/${firstProgram.programId}`,
-        { headers: { Authorization: `Bearer ${token}` } }
-      );
-      const brandData = await brandRes.json();
-      setBranding(brandData);
-    }
-
-    setLoggedIn(true);
+  // Wrapper callbacks for header buttons
+  const handleLoginPress = () => {
+    onPressLogin && onPressLogin();
   };
-  const handleLogout = () => {
-    setLoggedIn(false);
-    setProgram(null);
-    setBranding(null);
+
+  const handleLogoutPress = () => {
+    onLogout && onLogout();
   };
-  const handleSchedule = () => alert('Show schedule! (demo)');
+
+  const handleSchedulePress = () => {
+    onSchedule && onSchedule();
+  };
 
   return (
     <LinearGradient
@@ -77,11 +53,11 @@ export default function HomeScreen() {
       <View style={styles.headerOuter}>
         <View style={styles.headerInner}>
           {!loggedIn ? (
-            <HeaderButton label="Login" onPress={handleLogin} />
+            <HeaderButton label="Login" onPress={handleLoginPress} />
           ) : (
             <>
-              <HeaderButton label="Schedule" onPress={handleSchedule} />
-              <HeaderButton label="Logout" onPress={handleLogout} />
+              <HeaderButton label="Schedule" onPress={handleSchedulePress} />
+              <HeaderButton label="Logout" onPress={handleLogoutPress} />
             </>
           )}
         </View>

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -11,7 +11,7 @@ const API_BASE = __DEV__
   ? 'http://192.168.1.171:3000'
   : 'https://boysstateappservices.up.railway.app';
 
-export default function LoginScreen() {
+export default function LoginScreen({ onLoginSuccess }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [message, setMessage] = useState('');
@@ -26,6 +26,22 @@ export default function LoginScreen() {
       });
       const data = await res.json();
       if (data.token) {
+        const token = data.token;
+        const programsRes = await fetch(`${API_BASE}/user-programs/${email}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const programsData = await programsRes.json();
+        const firstProgram = programsData.programs?.[0];
+        let brandData = null;
+        if (firstProgram) {
+          const brandRes = await fetch(
+            `${API_BASE}/api/branding-contact/${firstProgram.programId}`,
+            { headers: { Authorization: `Bearer ${token}` } }
+          );
+          brandData = await brandRes.json();
+        }
+        onLoginSuccess &&
+          onLoginSuccess({ token, program: firstProgram, branding: brandData });
         setMessage('Logged in successfully!');
       } else {
         setMessage('Login failed');


### PR DESCRIPTION
## Summary
- add simple navigation state to `App`
- update `HomeScreen` to be stateless and trigger callbacks
- enhance `LoginScreen` to fetch program branding and report success
- adjust tests for new flow and navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6872b86620cc832da76dd02ab2ceaa61