### PR TITLE
Improve login screen styling

### DIFF
--- a/App.js
+++ b/App.js
@@ -29,7 +29,7 @@ export default function App() {
   let ScreenComponent;
   if (currentScreen === 'Login') {
     ScreenComponent = (
-      <LoginScreen onLoginSuccess={handleLoginSuccess} />
+      <LoginScreen onLoginSuccess={handleLoginSuccess} branding={branding} />
     );
   } else if (currentScreen === 'Schedule') {
     ScreenComponent = <ScheduleScreen />;

--- a/branding.js
+++ b/branding.js
@@ -1,0 +1,30 @@
+export const DEFAULT_COLORS = {
+  primary: '#204080',
+  secondary: '#1A6BC6',
+  accent: '#FFD166',
+  text: '#fff',
+  white: '#fff',
+  transparent: 'rgba(255,255,255,0.08)',
+};
+
+export function getColors(branding) {
+  return {
+    ...DEFAULT_COLORS,
+    ...(branding && branding.colors),
+  };
+}
+
+export const DEFAULT_ASSETS = {
+  logo: require('./assets/Boys State App Blue on Transparent.png'),
+  icon: require('./assets/Boys State Shield Blue on Transparent.png'),
+  banner: null,
+};
+
+export function getAssets(branding) {
+  return {
+    logo: branding && branding.logo ? { uri: branding.logo } : DEFAULT_ASSETS.logo,
+    icon: branding && branding.icon ? { uri: branding.icon } : DEFAULT_ASSETS.icon,
+    banner:
+      branding && branding.banner ? { uri: branding.banner } : DEFAULT_ASSETS.banner,
+  };
+}

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,17 +1,11 @@
 import React, { useEffect } from 'react';
 import { View, Text, Image, StyleSheet, TouchableOpacity, Dimensions, Platform, StatusBar } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
+import { DEFAULT_COLORS, getColors, getAssets } from '../branding';
 
 const { width } = Dimensions.get('window');
 
-const COLORS = {
-  primary: '#204080',
-  secondary: '#1A6BC6',
-  accent: '#FFD166',
-  text: '#fff',
-  white: '#fff',
-  transparent: 'rgba(255,255,255,0.08)',
-};
+const COLORS = { ...DEFAULT_COLORS };
 
 export default function HomeScreen({
   loggedIn = false,
@@ -23,10 +17,13 @@ export default function HomeScreen({
 }) {
 
   useEffect(() => {
-    if (branding && branding.colors) {
-      COLORS.primary = branding.colors.primary || COLORS.primary;
-      COLORS.secondary = branding.colors.secondary || COLORS.secondary;
-    }
+    const merged = getColors(branding);
+    COLORS.primary = merged.primary;
+    COLORS.secondary = merged.secondary;
+    COLORS.accent = merged.accent;
+    COLORS.text = merged.text;
+    COLORS.white = merged.white;
+    COLORS.transparent = merged.transparent;
   }, [branding]);
 
   // Wrapper callbacks for header buttons
@@ -41,6 +38,8 @@ export default function HomeScreen({
   const handleSchedulePress = () => {
     onSchedule && onSchedule();
   };
+
+  const { logo } = getAssets(branding);
 
   return (
     <LinearGradient
@@ -67,7 +66,7 @@ export default function HomeScreen({
       <View style={styles.flexGrow}>
         <View style={styles.container}>
           <Image
-            source={require('../assets/Boys State App Blue on Transparent.png')}
+            source={logo}
             style={styles.logo}
             resizeMode="contain"
             accessible

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -1,20 +1,37 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
   StyleSheet,
   TextInput,
   TouchableOpacity,
+  Image,
 } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { DEFAULT_COLORS, getColors, getAssets } from '../branding';
 
 const API_BASE = __DEV__
   ? 'http://192.168.1.171:3000'
   : 'https://boysstateappservices.up.railway.app';
 
-export default function LoginScreen({ onLoginSuccess }) {
+const COLORS = { ...DEFAULT_COLORS };
+
+export default function LoginScreen({ onLoginSuccess, branding = null }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const merged = getColors(branding);
+    COLORS.primary = merged.primary;
+    COLORS.secondary = merged.secondary;
+    COLORS.accent = merged.accent;
+    COLORS.text = merged.text;
+    COLORS.white = merged.white;
+    COLORS.transparent = merged.transparent;
+  }, [branding]);
+
+  const { logo } = getAssets(branding);
 
   const handleLogin = async () => {
     setMessage('');
@@ -52,45 +69,84 @@ export default function LoginScreen({ onLoginSuccess }) {
   };
 
   return (
-    <View style={styles.container} testID="login-screen">
-      <Text accessibilityRole="header">Login Screen</Text>
-      <TextInput
-        placeholder="Email"
-        value={email}
-        onChangeText={setEmail}
-        autoCapitalize="none"
-        style={styles.input}
-      />
-      <TextInput
-        placeholder="Password"
-        value={password}
-        onChangeText={setPassword}
-        secureTextEntry
-        style={styles.input}
-      />
-      <TouchableOpacity
-        onPress={handleLogin}
-        style={styles.button}
-        accessibilityRole="button"
-      >
-        <Text style={styles.buttonText}>Login</Text>
-      </TouchableOpacity>
-      {!!message && (
-        <Text testID="login-message" style={styles.message}>
-          {message}
-        </Text>
-      )}
-    </View>
+    <LinearGradient
+      colors={[COLORS.primary, COLORS.secondary]}
+      start={{ x: 0.2, y: 0.2 }}
+      end={{ x: 1, y: 1 }}
+      style={styles.gradient}
+    >
+      <View style={styles.flexGrow}>
+        <View style={styles.container} testID="login-screen">
+          <Image
+            source={logo}
+            style={styles.logo}
+            resizeMode="contain"
+            accessible
+            accessibilityLabel="Boys State App Logo"
+          />
+          <Text accessibilityRole="header" style={styles.title}>
+            Login Screen
+          </Text>
+          <TextInput
+            placeholder="Email"
+            value={email}
+            onChangeText={setEmail}
+            autoCapitalize="none"
+            style={styles.input}
+          />
+          <TextInput
+            placeholder="Password"
+            value={password}
+            onChangeText={setPassword}
+            secureTextEntry
+            style={styles.input}
+          />
+          <TouchableOpacity
+            onPress={handleLogin}
+            style={styles.button}
+            accessibilityRole="button"
+          >
+            <Text style={styles.buttonText}>Login</Text>
+          </TouchableOpacity>
+          {!!message && (
+            <Text testID="login-message" style={styles.message}>
+              {message}
+            </Text>
+          )}
+        </View>
+      </View>
+    </LinearGradient>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  gradient: {
     flex: 1,
+  },
+  flexGrow: {
+    flex: 1,
+    width: '100%',
+    justifyContent: 'center',
     alignItems: 'center',
-    justifyContent: 'flex-start',
-    paddingTop: 20,
-    backgroundColor: '#f2f2f2',
+  },
+  container: {
+    alignItems: 'center',
+    width: '90%',
+    backgroundColor: COLORS.transparent,
+    borderRadius: 22,
+    padding: 32,
+  },
+  logo: {
+    width: 200,
+    height: 100,
+    marginBottom: 20,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    color: COLORS.white,
+    marginBottom: 12,
+    textAlign: 'center',
   },
   input: {
     width: '90%',
@@ -103,7 +159,7 @@ const styles = StyleSheet.create({
     marginTop: 20,
     paddingVertical: 10,
     paddingHorizontal: 20,
-    backgroundColor: '#204080',
+    backgroundColor: COLORS.primary,
     borderRadius: 4,
   },
   buttonText: {


### PR DESCRIPTION
## Summary
- create branding helper for colors/assets
- apply branding in HomeScreen
- style LoginScreen with gradient and logo
- pass branding to LoginScreen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6872cc7b058c832dbbbe7674faaf4de4