### PR TITLE
Fix dynamic branding

### DIFF
--- a/App.js
+++ b/App.js
@@ -32,7 +32,7 @@ export default function App() {
       <LoginScreen onLoginSuccess={handleLoginSuccess} branding={branding} />
     );
   } else if (currentScreen === 'Schedule') {
-    ScreenComponent = <ScheduleScreen />;
+    ScreenComponent = <ScheduleScreen branding={branding} />;
   } else {
     ScreenComponent = (
       <HomeScreen
@@ -47,7 +47,7 @@ export default function App() {
   }
 
   return (
-    <SafeAreaView style={[styles.container, { paddingTop }]}>\
+    <SafeAreaView style={[styles.container, { paddingTop }]}>
       {ScreenComponent}
       <ExpoStatusBar style="light" />
     </SafeAreaView>

--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ See [`AGENTS.md`](./AGENTS.md) in this repo for a full breakdown of all user rol
 * All logic/features must include automated tests and follow repo linting rules.
 * Submit pull requests with clear explanations and test coverage.
 * See [Backend Services](https://github.com/yourorg/boysstate-backend) and [Web Admin Portal](https://github.com/yourorg/boysstate-admin) for backend/admin changes.
+<!-- Repository Note: This project is not affiliated with or endorsed by The American Legion. -->

--- a/__tests__/LoginScreen.test.js
+++ b/__tests__/LoginScreen.test.js
@@ -16,7 +16,8 @@ test('submits credentials and fetches branding', async () => {
         Promise.resolve({ programs: [{ programId: 'abc', programName: 'Test' }] }),
     })
     .mockResolvedValueOnce({
-      json: () => Promise.resolve({ colors: { primary: '#111', secondary: '#222' } }),
+      json: () =>
+        Promise.resolve({ colorPrimary: '#111', colorSecondary: '#222' }),
     });
 
   const onLoginSuccess = jest.fn();
@@ -39,7 +40,7 @@ test('submits credentials and fetches branding', async () => {
   expect(onLoginSuccess).toHaveBeenCalledWith({
     token: 't',
     program: { programId: 'abc', programName: 'Test' },
-    branding: { colors: { primary: '#111', secondary: '#222' } },
+    branding: { colorPrimary: '#111', colorSecondary: '#222' },
   });
   delete global.__DEV__;
 });

--- a/branding.js
+++ b/branding.js
@@ -3,14 +3,20 @@ export const DEFAULT_COLORS = {
   secondary: '#1A6BC6',
   accent: '#FFD166',
   text: '#fff',
+  background: '#ffffff',
   white: '#fff',
   transparent: 'rgba(255,255,255,0.08)',
 };
 
 export function getColors(branding) {
   return {
-    ...DEFAULT_COLORS,
-    ...(branding && branding.colors),
+    primary: branding?.colorPrimary || DEFAULT_COLORS.primary,
+    secondary: branding?.colorSecondary || DEFAULT_COLORS.secondary,
+    accent: branding?.colorAccent || DEFAULT_COLORS.accent,
+    text: branding?.colorText || DEFAULT_COLORS.text,
+    background: branding?.colorBackground || DEFAULT_COLORS.background,
+    white: DEFAULT_COLORS.white,
+    transparent: DEFAULT_COLORS.transparent,
   };
 }
 
@@ -22,9 +28,8 @@ export const DEFAULT_ASSETS = {
 
 export function getAssets(branding) {
   return {
-    logo: branding && branding.logo ? { uri: branding.logo } : DEFAULT_ASSETS.logo,
-    icon: branding && branding.icon ? { uri: branding.icon } : DEFAULT_ASSETS.icon,
-    banner:
-      branding && branding.banner ? { uri: branding.banner } : DEFAULT_ASSETS.banner,
+    logo: branding?.logoUrl ? { uri: branding.logoUrl } : DEFAULT_ASSETS.logo,
+    icon: branding?.iconUrl ? { uri: branding.iconUrl } : DEFAULT_ASSETS.icon,
+    banner: branding?.bannerUrl ? { uri: branding.bannerUrl } : DEFAULT_ASSETS.banner,
   };
 }

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,11 +1,18 @@
-import React, { useEffect } from 'react';
-import { View, Text, Image, StyleSheet, TouchableOpacity, Dimensions, Platform, StatusBar } from 'react-native';
+import React from 'react';
+import {
+  View,
+  Text,
+  Image,
+  StyleSheet,
+  TouchableOpacity,
+  Dimensions,
+  Platform,
+  StatusBar,
+} from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { DEFAULT_COLORS, getColors, getAssets } from '../branding';
+import { getColors, getAssets } from '../branding';
 
 const { width } = Dimensions.get('window');
-
-const COLORS = { ...DEFAULT_COLORS };
 
 export default function HomeScreen({
   loggedIn = false,
@@ -15,18 +22,9 @@ export default function HomeScreen({
   onLogout,
   onSchedule,
 }) {
+  const colors = getColors(branding);
+  const { logo } = getAssets(branding);
 
-  useEffect(() => {
-    const merged = getColors(branding);
-    COLORS.primary = merged.primary;
-    COLORS.secondary = merged.secondary;
-    COLORS.accent = merged.accent;
-    COLORS.text = merged.text;
-    COLORS.white = merged.white;
-    COLORS.transparent = merged.transparent;
-  }, [branding]);
-
-  // Wrapper callbacks for header buttons
   const handleLoginPress = () => {
     onPressLogin && onPressLogin();
   };
@@ -39,17 +37,19 @@ export default function HomeScreen({
     onSchedule && onSchedule();
   };
 
-  const { logo } = getAssets(branding);
-
   return (
     <LinearGradient
-      colors={[COLORS.primary, COLORS.secondary]}
+      colors={[colors.primary, colors.secondary]}
       start={{ x: 0.2, y: 0.2 }}
       end={{ x: 1, y: 1 }}
       style={styles.gradient}
     >
-      {/* Header */}
-      <View style={styles.headerOuter}>
+      <View
+        style={[
+          styles.headerOuter,
+          { backgroundColor: 'rgba(32, 64, 128, 0.09)' },
+        ]}
+      >
         <View style={styles.headerInner}>
           {!loggedIn ? (
             <HeaderButton label="Login" onPress={handleLoginPress} />
@@ -62,9 +62,8 @@ export default function HomeScreen({
         </View>
       </View>
 
-      {/* Main Content */}
       <View style={styles.flexGrow}>
-        <View style={styles.container}>
+        <View style={[styles.container, { backgroundColor: colors.transparent }]}> 
           <Image
             source={logo}
             style={styles.logo}
@@ -72,16 +71,16 @@ export default function HomeScreen({
             accessible
             accessibilityLabel="Boys State App Logo"
           />
-          <Text style={styles.title} testID="program-name">
+          <Text style={[styles.title, { color: colors.white }]} testID="program-name">
             {program ? `Welcome to ${program.programName}!` : 'Welcome to Boys State!'}
           </Text>
-          <Text style={styles.subtitle}>
+          <Text style={[styles.subtitle, { color: colors.white }] }>
             {loggedIn
               ? 'Check your schedule, explore resources, and make the most of your experience.'
               : "Log in to get started! You'll see your schedule and updates once you're signed in."}
           </Text>
           {program && (
-            <Text style={styles.program} testID="assigned-program">
+            <Text style={[styles.program, { color: colors.white }]} testID="assigned-program">
               {`Program ID: ${program.programId}`}
             </Text>
           )}
@@ -103,13 +102,11 @@ const styles = StyleSheet.create({
   gradient: {
     flex: 1,
   },
-  // Header is OUTSIDE main content, padded for notch/safe area
   headerOuter: {
     paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight || 32 : 48,
     paddingBottom: 0,
     paddingHorizontal: 18,
     width: '100%',
-    backgroundColor: 'rgba(32, 64, 128, 0.09)', // slight glass effect
   },
   headerInner: {
     flexDirection: 'row',
@@ -127,7 +124,7 @@ const styles = StyleSheet.create({
     borderColor: 'rgba(255,255,255,0.16)',
   },
   headerButtonText: {
-    color: COLORS.white,
+    color: '#fff',
     fontWeight: 'bold',
     fontSize: 16,
     letterSpacing: 0.2,
@@ -135,7 +132,6 @@ const styles = StyleSheet.create({
     textShadowOffset: { width: 0, height: 1 },
     textShadowRadius: 4,
   },
-  // Main content fills available space below header, centers card
   flexGrow: {
     flex: 1,
     width: '100%',
@@ -145,7 +141,6 @@ const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
     width: width - 40,
-    backgroundColor: COLORS.transparent,
     borderRadius: 22,
     padding: 32,
     shadowColor: '#000',
@@ -162,7 +157,6 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 28,
     fontWeight: 'bold',
-    color: COLORS.white,
     marginBottom: 14,
     textAlign: 'center',
     textShadowColor: 'rgba(0,0,0,0.18)',
@@ -171,13 +165,11 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     fontSize: 18,
-    color: COLORS.white,
     opacity: 0.97,
     textAlign: 'center',
   },
   program: {
     fontSize: 16,
-    color: COLORS.white,
     marginTop: 6,
     textAlign: 'center',
   },

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import {
   View,
   Text,
@@ -8,29 +8,18 @@ import {
   Image,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { DEFAULT_COLORS, getColors, getAssets } from '../branding';
+import { getColors, getAssets } from '../branding';
 
 const API_BASE = __DEV__
   ? 'http://192.168.1.171:3000'
   : 'https://boysstateappservices.up.railway.app';
-
-const COLORS = { ...DEFAULT_COLORS };
 
 export default function LoginScreen({ onLoginSuccess, branding = null }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [message, setMessage] = useState('');
 
-  useEffect(() => {
-    const merged = getColors(branding);
-    COLORS.primary = merged.primary;
-    COLORS.secondary = merged.secondary;
-    COLORS.accent = merged.accent;
-    COLORS.text = merged.text;
-    COLORS.white = merged.white;
-    COLORS.transparent = merged.transparent;
-  }, [branding]);
-
+  const colors = getColors(branding);
   const { logo } = getAssets(branding);
 
   const handleLogin = async () => {
@@ -70,13 +59,16 @@ export default function LoginScreen({ onLoginSuccess, branding = null }) {
 
   return (
     <LinearGradient
-      colors={[COLORS.primary, COLORS.secondary]}
+      colors={[colors.primary, colors.secondary]}
       start={{ x: 0.2, y: 0.2 }}
       end={{ x: 1, y: 1 }}
       style={styles.gradient}
     >
       <View style={styles.flexGrow}>
-        <View style={styles.container} testID="login-screen">
+        <View
+          style={[styles.container, { backgroundColor: colors.transparent }]}
+          testID="login-screen"
+        >
           <Image
             source={logo}
             style={styles.logo}
@@ -84,7 +76,7 @@ export default function LoginScreen({ onLoginSuccess, branding = null }) {
             accessible
             accessibilityLabel="Boys State App Logo"
           />
-          <Text accessibilityRole="header" style={styles.title}>
+          <Text accessibilityRole="header" style={[styles.title, { color: colors.white }]}> 
             Login Screen
           </Text>
           <TextInput
@@ -103,7 +95,7 @@ export default function LoginScreen({ onLoginSuccess, branding = null }) {
           />
           <TouchableOpacity
             onPress={handleLogin}
-            style={styles.button}
+            style={[styles.button, { backgroundColor: colors.primary }]}
             accessibilityRole="button"
           >
             <Text style={styles.buttonText}>Login</Text>
@@ -132,7 +124,6 @@ const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
     width: '90%',
-    backgroundColor: COLORS.transparent,
     borderRadius: 22,
     padding: 32,
   },
@@ -144,7 +135,6 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 28,
     fontWeight: 'bold',
-    color: COLORS.white,
     marginBottom: 12,
     textAlign: 'center',
   },
@@ -159,7 +149,6 @@ const styles = StyleSheet.create({
     marginTop: 20,
     paddingVertical: 10,
     paddingHorizontal: 20,
-    backgroundColor: COLORS.primary,
     borderRadius: 4,
   },
   buttonText: {

--- a/screens/ScheduleScreen.js
+++ b/screens/ScheduleScreen.js
@@ -1,9 +1,14 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { getColors } from '../branding';
 
-export default function ScheduleScreen() {
+export default function ScheduleScreen({ branding = null }) {
+  const colors = getColors(branding);
   return (
-    <View style={styles.container} testID="schedule-screen">
+    <View
+      style={[styles.container, { backgroundColor: colors.background }]}
+      testID="schedule-screen"
+    >
       <Text accessibilityRole="header">Schedule Screen</Text>
     </View>
   );
@@ -15,6 +20,5 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'flex-start',
     paddingTop: 20,
-    backgroundColor: '#f2f2f2',
   },
 });


### PR DESCRIPTION
## Summary
- rework branding utilities to use API field names
- update HomeScreen and LoginScreen to consume branding each render
- theme ScheduleScreen and pass branding through navigation
- adjust login test for new branding response

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6872d18f6c18832dab3ec8a4f5de57c3