### PR TITLE
Add cancel button to login screen

### DIFF
--- a/App.js
+++ b/App.js
@@ -29,7 +29,11 @@ export default function App() {
   let ScreenComponent;
   if (currentScreen === 'Login') {
     ScreenComponent = (
-      <LoginScreen onLoginSuccess={handleLoginSuccess} branding={branding} />
+      <LoginScreen
+        onLoginSuccess={handleLoginSuccess}
+        onCancel={() => setCurrentScreen('Home')}
+        branding={branding}
+      />
     );
   } else if (currentScreen === 'Schedule') {
     ScreenComponent = <ScheduleScreen branding={branding} />;

--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -22,3 +22,11 @@ test('navigates to login screen when login pressed', () => {
   fireEvent.press(getByText('Login'));
   expect(getByTestId('login-screen')).toBeTruthy();
 });
+
+test('cancel from login returns to home screen', () => {
+  const App = require('../App').default;
+  const { getByText, getByTestId } = render(<App />);
+  fireEvent.press(getByText('Login'));
+  fireEvent.press(getByText('Cancel'));
+  expect(getByTestId('program-name')).toBeTruthy();
+});

--- a/__tests__/LoginScreen.test.js
+++ b/__tests__/LoginScreen.test.js
@@ -7,6 +7,13 @@ test('displays Login Screen header', () => {
   expect(getByRole('header').props.children).toBe('Login Screen');
 });
 
+test('calls onCancel when cancel pressed', () => {
+  const onCancel = jest.fn();
+  const { getByText } = render(<LoginScreen onCancel={onCancel} />);
+  fireEvent.press(getByText('Cancel'));
+  expect(onCancel).toHaveBeenCalled();
+});
+
 test('submits credentials and fetches branding', async () => {
   global.__DEV__ = true;
   fetch
@@ -42,5 +49,22 @@ test('submits credentials and fetches branding', async () => {
     program: { programId: 'abc', programName: 'Test' },
     branding: { colorPrimary: '#111', colorSecondary: '#222' },
   });
+  delete global.__DEV__;
+});
+
+test('shows error message when login fails', async () => {
+  global.__DEV__ = true;
+  fetch.mockResolvedValueOnce({ json: () => Promise.resolve({}) });
+
+  const { getByPlaceholderText, getByText, getByTestId } = render(
+    <LoginScreen />
+  );
+  fireEvent.changeText(getByPlaceholderText('Email'), 'fail@example.com');
+  fireEvent.changeText(getByPlaceholderText('Password'), 'pass');
+  fireEvent.press(getByText('Login'));
+
+  await waitFor(() => getByTestId('login-message'));
+
+  expect(getByTestId('login-message').props.children).toBe('Login failed');
   delete global.__DEV__;
 });

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -14,7 +14,7 @@ const API_BASE = __DEV__
   ? 'http://192.168.1.171:3000'
   : 'https://boysstateappservices.up.railway.app';
 
-export default function LoginScreen({ onLoginSuccess, branding = null }) {
+export default function LoginScreen({ onLoginSuccess, onCancel, branding = null }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [message, setMessage] = useState('');
@@ -99,6 +99,13 @@ export default function LoginScreen({ onLoginSuccess, branding = null }) {
             accessibilityRole="button"
           >
             <Text style={styles.buttonText}>Login</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() => onCancel && onCancel()}
+            style={[styles.button, { backgroundColor: colors.secondary }]}
+            accessibilityRole="button"
+          >
+            <Text style={styles.buttonText}>Cancel</Text>
           </TouchableOpacity>
           {!!message && (
             <Text testID="login-message" style={styles.message}>


### PR DESCRIPTION
## Summary
- allow canceling login
- make app return to Home screen when canceling
- update tests for LoginScreen and App

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6872d75ee6f0832dbec7e2fe615a5c5a