### PR TITLE
Fix dynamic logo loading with branding URLs

### DIFF
--- a/__tests__/branding.test.js
+++ b/__tests__/branding.test.js
@@ -1,0 +1,12 @@
+import { getAssets, DEFAULT_ASSETS } from '../branding';
+
+test('getAssets returns remote logo when url provided', () => {
+  const branding = { logoUrl: 'https://example.com/logo.png' };
+  const assets = getAssets(branding);
+  expect(assets.logo).toEqual({ uri: 'https://example.com/logo.png' });
+});
+
+test('getAssets falls back to default logo when url invalid', () => {
+  const assets = getAssets({ logoUrl: '' });
+  expect(assets.logo).toBe(DEFAULT_ASSETS.logo);
+});

--- a/branding.js
+++ b/branding.js
@@ -26,10 +26,22 @@ export const DEFAULT_ASSETS = {
   banner: null,
 };
 
+function isValidUrl(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
 export function getAssets(branding) {
   return {
-    logo: branding?.logoUrl ? { uri: branding.logoUrl } : DEFAULT_ASSETS.logo,
-    icon: branding?.iconUrl ? { uri: branding.iconUrl } : DEFAULT_ASSETS.icon,
-    banner: branding?.bannerUrl ? { uri: branding.bannerUrl } : DEFAULT_ASSETS.banner,
+    logo: isValidUrl(branding?.logoUrl)
+      ? { uri: branding.logoUrl }
+      : DEFAULT_ASSETS.logo,
+    icon: isValidUrl(branding?.iconUrl)
+      ? { uri: branding.iconUrl }
+      : DEFAULT_ASSETS.icon,
+    banner: isValidUrl(branding?.bannerUrl)
+      ? { uri: branding.bannerUrl }
+      : DEFAULT_ASSETS.banner,
   };
 }
+
+export { isValidUrl };


### PR DESCRIPTION
## Summary
- improve `getAssets` to validate branding URLs
- add unit tests covering dynamic asset selection

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6872d782ef58832d8d34aaacc80b7fee