### PR TITLE
Fix remote home logo loading

### DIFF
--- a/__mocks__/expo-file-system.js
+++ b/__mocks__/expo-file-system.js
@@ -1,0 +1,5 @@
+module.exports = {
+  cacheDirectory: '',
+  getInfoAsync: jest.fn(() => Promise.resolve({ exists: false })),
+  downloadAsync: jest.fn((uri, dest) => Promise.resolve({ uri: dest })),
+};

--- a/__tests__/HomeScreen.test.js
+++ b/__tests__/HomeScreen.test.js
@@ -44,3 +44,20 @@ test('shows program ID when provided', () => {
     `Program ID: ${program.programId}`
   );
 });
+
+test('uses cached branding logo when available', () => {
+  jest.resetModules();
+  jest.doMock('../utils/useCachedImage', () => jest.fn(() => ({ uri: 'cached.png' })));
+  const Home = require('../screens/HomeScreen').default;
+  const { getByLabelText } = render(<Home branding={{ logoUrl: 'https://x/logo.png' }} />);
+  expect(getByLabelText('Boys State App Logo').props.source).toEqual({ uri: 'cached.png' });
+});
+
+test('falls back to default logo when cache missing', () => {
+  jest.resetModules();
+  jest.doMock('../utils/useCachedImage', () => jest.fn(() => null));
+  const { DEFAULT_ASSETS } = require('../branding');
+  const Home = require('../screens/HomeScreen').default;
+  const { getByLabelText } = render(<Home branding={{ logoUrl: 'https://x/logo.png' }} />);
+  expect(getByLabelText('Boys State App Logo').props.source).toBe(DEFAULT_ASSETS.logo);
+});

--- a/__tests__/branding.test.js
+++ b/__tests__/branding.test.js
@@ -10,3 +10,8 @@ test('getAssets falls back to default logo when url invalid', () => {
   const assets = getAssets({ logoUrl: '' });
   expect(assets.logo).toBe(DEFAULT_ASSETS.logo);
 });
+
+test('getAssets falls back when url lacks protocol', () => {
+  const assets = getAssets({ logoUrl: '/path/to/logo.png' });
+  expect(assets.logo).toBe(DEFAULT_ASSETS.logo);
+});

--- a/branding.js
+++ b/branding.js
@@ -27,7 +27,10 @@ export const DEFAULT_ASSETS = {
 };
 
 function isValidUrl(value) {
-  return typeof value === 'string' && value.trim().length > 0;
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  return /^https?:\/\//i.test(trimmed);
 }
 
 export function getAssets(branding) {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,4 +1,5 @@
 jest.mock('react-native');
 jest.mock('expo-status-bar');
+jest.mock('expo-file-system');
 
 global.fetch = jest.fn();

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -10,8 +10,9 @@ import {
   StatusBar,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { getColors, getAssets } from '../branding';
+import { getColors, DEFAULT_ASSETS, isValidUrl } from '../branding';
 import { lighten } from '../utils/colors';
+import useCachedImage from '../utils/useCachedImage';
 
 const { width } = Dimensions.get('window');
 
@@ -24,7 +25,10 @@ export default function HomeScreen({
   onSchedule,
 }) {
   const colors = getColors(branding);
-  const { logo } = getAssets(branding);
+  const defaultLogo = DEFAULT_ASSETS.logo;
+  const remoteUrl = isValidUrl(branding?.logoUrl) ? branding.logoUrl : null;
+  const cachedLogo = useCachedImage(remoteUrl);
+  const logo = remoteUrl ? cachedLogo || defaultLogo : defaultLogo;
 
   const handleLoginPress = () => {
     onPressLogin && onPressLogin();

--- a/utils/useCachedImage.js
+++ b/utils/useCachedImage.js
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react';
+import * as FileSystem from 'expo-file-system';
+
+export default function useCachedImage(uri) {
+  const [source, setSource] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      if (!uri) {
+        return;
+      }
+      try {
+        const cacheFile = FileSystem.cacheDirectory + encodeURIComponent(uri);
+        const info = await FileSystem.getInfoAsync(cacheFile);
+        if (info.exists) {
+          if (!cancelled) setSource({ uri: info.uri });
+        } else {
+          const download = await FileSystem.downloadAsync(uri, cacheFile);
+          if (!cancelled) setSource({ uri: download.uri });
+        }
+      } catch {
+        if (!cancelled) setSource(null);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [uri]);
+
+  return source;
+}


### PR DESCRIPTION
## Summary
- cache remote images via expo-file-system
- support only HTTP/S urls in branding assets
- display cached logo on Home screen and fallback if unavailable
- mock expo-file-system for tests
- test branding URLs and cached logo behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6872d9f7eb3c832d933a1f308ea05887