### PR TITLE
Improve branding image caching

### DIFF
--- a/__mocks__/expo-file-system.js
+++ b/__mocks__/expo-file-system.js
@@ -1,5 +1,6 @@
 module.exports = {
-  cacheDirectory: '',
+  cacheDirectory: '/cache/',
   getInfoAsync: jest.fn(() => Promise.resolve({ exists: false })),
+  makeDirectoryAsync: jest.fn(() => Promise.resolve()),
   downloadAsync: jest.fn((uri, dest) => Promise.resolve({ uri: dest })),
 };

--- a/__tests__/useCachedImage.test.js
+++ b/__tests__/useCachedImage.test.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import { Image } from 'react-native';
+import useCachedImage from '../utils/useCachedImage';
+import * as FileSystem from 'expo-file-system';
+
+function Test({ uri }) {
+  const source = useCachedImage(uri);
+  return <Image source={source} testID="img" />;
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test('uses cached file when it exists', async () => {
+  FileSystem.getInfoAsync.mockResolvedValueOnce({ exists: true, uri: '/cache/images/x' });
+  const { getByTestId } = render(<Test uri="https://host/logo.png" />);
+  await waitFor(() => expect(getByTestId('img').props.source).toEqual({ uri: '/cache/images/x' }));
+  expect(FileSystem.downloadAsync).not.toHaveBeenCalled();
+});
+
+test('downloads file when not cached', async () => {
+  FileSystem.getInfoAsync.mockResolvedValueOnce({ exists: false });
+  const { getByTestId } = render(<Test uri="https://host/logo.png" />);
+  const target = '/cache/images/' + encodeURIComponent('https://host/logo.png');
+  await waitFor(() => expect(FileSystem.downloadAsync).toHaveBeenCalledWith('https://host/logo.png', target));
+  expect(FileSystem.makeDirectoryAsync).toHaveBeenCalledWith('/cache/images/', { intermediates: true });
+  await waitFor(() => expect(getByTestId('img').props.source).toEqual({ uri: target }));
+});
+
+test('logs error and returns null on failure', async () => {
+  FileSystem.getInfoAsync.mockResolvedValueOnce({ exists: false });
+  FileSystem.downloadAsync.mockRejectedValueOnce(new Error('fail'));
+  const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  render(<Test uri="https://host/logo.png" />);
+  await waitFor(() => expect(FileSystem.downloadAsync).toHaveBeenCalled());
+  expect(errSpy).toHaveBeenCalled();
+  errSpy.mockRestore();
+});


### PR DESCRIPTION
## Summary
- fix caching path handling and ensure cache directories exist
- log download errors and sanitize remote filenames
- extend expo-file-system test mock
- add unit tests for image caching hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6872eb106bd0832d8b43698ba41e3421