### PR TITLE
Fix directory creation for cached images

### DIFF
--- a/__tests__/useCachedImage.test.js
+++ b/__tests__/useCachedImage.test.js
@@ -14,23 +14,34 @@ afterEach(() => {
 });
 
 test('uses cached file when it exists', async () => {
-  FileSystem.getInfoAsync.mockResolvedValueOnce({ exists: true, uri: '/cache/images/x' });
+  FileSystem.getInfoAsync
+    .mockResolvedValueOnce({ exists: true })
+    .mockResolvedValueOnce({ exists: true, uri: '/cache/images/x' });
   const { getByTestId } = render(<Test uri="https://host/logo.png" />);
-  await waitFor(() => expect(getByTestId('img').props.source).toEqual({ uri: '/cache/images/x' }));
+  await waitFor(() =>
+    expect(getByTestId('img').props.source).toEqual({ uri: '/cache/images/x' })
+  );
+  expect(FileSystem.makeDirectoryAsync).not.toHaveBeenCalled();
   expect(FileSystem.downloadAsync).not.toHaveBeenCalled();
 });
 
-test('downloads file when not cached', async () => {
-  FileSystem.getInfoAsync.mockResolvedValueOnce({ exists: false });
+test('downloads file when not cached and directory is created', async () => {
+  FileSystem.getInfoAsync
+    .mockResolvedValueOnce({ exists: false })
+    .mockResolvedValueOnce({ exists: false });
   const { getByTestId } = render(<Test uri="https://host/logo.png" />);
   const target = '/cache/images/' + encodeURIComponent('https://host/logo.png');
-  await waitFor(() => expect(FileSystem.downloadAsync).toHaveBeenCalledWith('https://host/logo.png', target));
+  await waitFor(() =>
+    expect(FileSystem.downloadAsync).toHaveBeenCalledWith('https://host/logo.png', target)
+  );
   expect(FileSystem.makeDirectoryAsync).toHaveBeenCalledWith('/cache/images/', { intermediates: true });
   await waitFor(() => expect(getByTestId('img').props.source).toEqual({ uri: target }));
 });
 
 test('logs error and returns null on failure', async () => {
-  FileSystem.getInfoAsync.mockResolvedValueOnce({ exists: false });
+  FileSystem.getInfoAsync
+    .mockResolvedValueOnce({ exists: true })
+    .mockResolvedValueOnce({ exists: false });
   FileSystem.downloadAsync.mockRejectedValueOnce(new Error('fail'));
   const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   render(<Test uri="https://host/logo.png" />);

--- a/utils/useCachedImage.js
+++ b/utils/useCachedImage.js
@@ -20,11 +20,12 @@ export default function useCachedImage(uri) {
       try {
         const dir = CACHE_DIR;
         try {
-          await FileSystem.makeDirectoryAsync(dir, { intermediates: true });
-        } catch (err) {
-          if (!/Directory .* already exists/.test(String(err))) {
-            console.error('Failed to create cache directory', err);
+          const dirInfo = await FileSystem.getInfoAsync(dir);
+          if (!dirInfo.exists) {
+            await FileSystem.makeDirectoryAsync(dir, { intermediates: true });
           }
+        } catch (err) {
+          console.error('Failed to ensure cache directory', err);
         }
 
         const cacheFile = dir + sanitize(uri);


### PR DESCRIPTION
## Summary
- ensure image cache directory exists before downloading
- update cached image tests for new directory check

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6872ed440f60832dbdcf9d6c2727b16e