### PR TITLE
Fix cache image directory creation

### DIFF
--- a/__tests__/useCachedImage.test.js
+++ b/__tests__/useCachedImage.test.js
@@ -14,34 +14,50 @@ afterEach(() => {
 });
 
 test('uses cached file when it exists', async () => {
+  const target = '/cache/images/' + encodeURIComponent('https://host/logo.png');
   FileSystem.getInfoAsync
-    .mockResolvedValueOnce({ exists: true })
-    .mockResolvedValueOnce({ exists: true, uri: '/cache/images/x' });
+    .mockResolvedValueOnce({ exists: true }) // /cache/
+    .mockResolvedValueOnce({ exists: true }) // /cache/images/
+    .mockResolvedValueOnce({ exists: true, uri: target }); // cache file
   const { getByTestId } = render(<Test uri="https://host/logo.png" />);
   await waitFor(() =>
-    expect(getByTestId('img').props.source).toEqual({ uri: '/cache/images/x' })
+    expect(getByTestId('img').props.source).toEqual({ uri: target })
   );
   expect(FileSystem.makeDirectoryAsync).not.toHaveBeenCalled();
   expect(FileSystem.downloadAsync).not.toHaveBeenCalled();
 });
 
-test('downloads file when not cached and directory is created', async () => {
+test('downloads file when not cached and directory path created', async () => {
   FileSystem.getInfoAsync
-    .mockResolvedValueOnce({ exists: false })
-    .mockResolvedValueOnce({ exists: false });
+    .mockResolvedValueOnce({ exists: false }) // /cache/
+    .mockResolvedValueOnce({ exists: false }) // /cache/images/
+    .mockResolvedValueOnce({ exists: false }); // cache file
   const { getByTestId } = render(<Test uri="https://host/logo.png" />);
   const target = '/cache/images/' + encodeURIComponent('https://host/logo.png');
   await waitFor(() =>
     expect(FileSystem.downloadAsync).toHaveBeenCalledWith('https://host/logo.png', target)
   );
-  expect(FileSystem.makeDirectoryAsync).toHaveBeenCalledWith('/cache/images/', { intermediates: true });
+  expect(FileSystem.makeDirectoryAsync).toHaveBeenNthCalledWith(1, '/cache/', { intermediates: true });
+  expect(FileSystem.makeDirectoryAsync).toHaveBeenNthCalledWith(2, '/cache/images/', { intermediates: true });
   await waitFor(() => expect(getByTestId('img').props.source).toEqual({ uri: target }));
+});
+
+test('creates missing parent directories recursively', async () => {
+  FileSystem.getInfoAsync
+    .mockResolvedValueOnce({ exists: false }) // /cache/
+    .mockResolvedValueOnce({ exists: false }) // /cache/images/
+    .mockResolvedValueOnce({ exists: false }); // cache file
+  render(<Test uri="https://host/logo.png" />);
+  await waitFor(() => expect(FileSystem.makeDirectoryAsync).toHaveBeenCalled());
+  expect(FileSystem.makeDirectoryAsync).toHaveBeenNthCalledWith(1, '/cache/', { intermediates: true });
+  expect(FileSystem.makeDirectoryAsync).toHaveBeenNthCalledWith(2, '/cache/images/', { intermediates: true });
 });
 
 test('logs error and returns null on failure', async () => {
   FileSystem.getInfoAsync
-    .mockResolvedValueOnce({ exists: true })
-    .mockResolvedValueOnce({ exists: false });
+    .mockResolvedValueOnce({ exists: true }) // /cache/
+    .mockResolvedValueOnce({ exists: true }) // /cache/images/
+    .mockResolvedValueOnce({ exists: false }); // cache file
   FileSystem.downloadAsync.mockRejectedValueOnce(new Error('fail'));
   const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   render(<Test uri="https://host/logo.png" />);

--- a/utils/useCachedImage.js
+++ b/utils/useCachedImage.js
@@ -3,6 +3,31 @@ import * as FileSystem from 'expo-file-system';
 
 const CACHE_DIR = FileSystem.cacheDirectory + 'images/';
 
+async function ensureDirectoryRecursive(dir) {
+  let base = '';
+  let path = dir;
+  if (path.startsWith('file://')) {
+    base = 'file://';
+    path = path.slice(7);
+  } else if (path.startsWith('/')) {
+    base = '/';
+    path = path.slice(1);
+  }
+  const parts = path.split('/').filter(Boolean);
+  let current = base;
+  for (const part of parts) {
+    current += part + '/';
+    try {
+      const info = await FileSystem.getInfoAsync(current);
+      if (!info.exists) {
+        await FileSystem.makeDirectoryAsync(current, { intermediates: true });
+      }
+    } catch (err) {
+      await FileSystem.makeDirectoryAsync(current, { intermediates: true });
+    }
+  }
+}
+
 function sanitize(uri) {
   return encodeURIComponent(uri);
 }
@@ -20,10 +45,7 @@ export default function useCachedImage(uri) {
       try {
         const dir = CACHE_DIR;
         try {
-          const dirInfo = await FileSystem.getInfoAsync(dir);
-          if (!dirInfo.exists) {
-            await FileSystem.makeDirectoryAsync(dir, { intermediates: true });
-          }
+          await ensureDirectoryRecursive(dir);
         } catch (err) {
           console.error('Failed to ensure cache directory', err);
         }


### PR DESCRIPTION
## Summary
- ensure useCachedImage creates each directory in its cache path
- update useCachedImage tests for recursive directory creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6873038b6f9c832dba32eb93d623e74e